### PR TITLE
feat: add simple findById method to ReservationQueryService

### DIFF
--- a/src/main/java/com/golfRental/domain/reservation/service/query/ReservationQueryService.java
+++ b/src/main/java/com/golfRental/domain/reservation/service/query/ReservationQueryService.java
@@ -1,8 +1,11 @@
 package com.golfRental.domain.reservation.service.query;
 
 import com.golfRental.domain.reservation.dto.response.ReservationGetResponse;
+import com.golfRental.domain.reservation.entity.Reservation;
 
 public interface ReservationQueryService {
 
     ReservationGetResponse findById(Long reservationId, Long currentUserId);
+
+    Reservation findById(Long reservationId);
 }

--- a/src/main/java/com/golfRental/domain/reservation/service/query/ReservationQueryServiceImpl.java
+++ b/src/main/java/com/golfRental/domain/reservation/service/query/ReservationQueryServiceImpl.java
@@ -42,4 +42,10 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
                 .status(reservation.getStatus())
                 .build();
     }
+
+    @Override
+    public Reservation findById(Long reservationId) {
+        return reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/golfRental/domain/reservation/service/query/ReservationQueryServiceImpl.java
+++ b/src/main/java/com/golfRental/domain/reservation/service/query/ReservationQueryServiceImpl.java
@@ -45,7 +45,7 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
 
     @Override
     public Reservation findById(Long reservationId) {
-        return reservationRepository.findById(reservationId)
+        return reservationRepository.findByIdWithDetails(reservationId)
                 .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 -->

- Closes #60
-  다른 도메인에서 예약 정보를 조회할 수 있도록 권한 검증이 없는 단순 조회 메서드 추가

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- ReservationQueryService에 `findById(Long reservationId)` 메서드 추가
- 권한 검증 없이 Reservation 엔티티를 직접 반환하여 다른 도메인에서 사용 가능
- 존재하지 않는 예약 조회 시 ReservationException 발생

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성
