### PR TITLE
[feature] Implement Category Update API

### DIFF
--- a/src/main/java/com/golfRental/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/golfRental/domain/category/controller/CategoryController.java
@@ -2,9 +2,11 @@ package com.golfRental.domain.category.controller;
 
 import com.golfRental.common.response.CommonApiResponse;
 import com.golfRental.domain.category.dto.request.CategoryCreateRequest;
+import com.golfRental.domain.category.dto.request.CategoryUpdateRequest;
 import com.golfRental.domain.category.dto.response.CategoryCreateResponse;
 import com.golfRental.domain.category.dto.response.CategoryGetAllResponse;
 import com.golfRental.domain.category.dto.response.CategoryGetResponse;
+import com.golfRental.domain.category.dto.response.CategoryUpdateResponse;
 import org.springframework.http.ResponseEntity;
 
 import java.util.List;
@@ -36,4 +38,15 @@ public interface CategoryController {
      */
     ResponseEntity<CommonApiResponse<CategoryGetResponse>>
     getCategoryById(Long categoryId);
+
+    /**
+     * 카테고리 수정 API (관리자 전용)
+     *
+     * @param categoryId            수정할 카테고리 ID
+     * @param categoryUpdateRequest 카테고리 수정 요청 DTO
+     * @return CategoryUpdateResponse
+     */
+    ResponseEntity<CommonApiResponse<CategoryUpdateResponse>>
+    updateCategory(Long categoryId, CategoryUpdateRequest categoryUpdateRequest);
+
 }

--- a/src/main/java/com/golfRental/domain/category/controller/CategoryControllerImpl.java
+++ b/src/main/java/com/golfRental/domain/category/controller/CategoryControllerImpl.java
@@ -2,9 +2,11 @@ package com.golfRental.domain.category.controller;
 
 import com.golfRental.common.response.CommonApiResponse;
 import com.golfRental.domain.category.dto.request.CategoryCreateRequest;
+import com.golfRental.domain.category.dto.request.CategoryUpdateRequest;
 import com.golfRental.domain.category.dto.response.CategoryCreateResponse;
 import com.golfRental.domain.category.dto.response.CategoryGetAllResponse;
 import com.golfRental.domain.category.dto.response.CategoryGetResponse;
+import com.golfRental.domain.category.dto.response.CategoryUpdateResponse;
 import com.golfRental.domain.category.message.CategorySuccessMessage;
 import com.golfRental.domain.category.service.command.CategoryCommandService;
 import com.golfRental.domain.category.service.query.CategoryQueryService;
@@ -60,6 +62,21 @@ public class CategoryControllerImpl implements CategoryController {
         return CommonApiResponse.success(
                 categoryGetResponse,
                 CategorySuccessMessage.CATEGORY_GET_SUCCESS
+        );
+    }
+
+    @Override
+    @PutMapping("/admin/categories/{categoryId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<CommonApiResponse<CategoryUpdateResponse>> updateCategory(
+            @PathVariable Long categoryId,
+            @Valid @RequestBody CategoryUpdateRequest request
+    ) {
+        CategoryUpdateResponse response = categoryCommandService.updateCategory(categoryId, request);
+
+        return CommonApiResponse.success(
+                response,
+                CategorySuccessMessage.CATEGORY_UPDATED
         );
     }
 }

--- a/src/main/java/com/golfRental/domain/category/dto/request/CategoryUpdateRequest.java
+++ b/src/main/java/com/golfRental/domain/category/dto/request/CategoryUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.golfRental.domain.category.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CategoryUpdateRequest {
+
+    @NotBlank(message = "카테고리 이름은 필수입니다.")
+    private String name;
+
+    public CategoryUpdateRequest(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/golfRental/domain/category/dto/response/CategoryUpdateResponse.java
+++ b/src/main/java/com/golfRental/domain/category/dto/response/CategoryUpdateResponse.java
@@ -1,0 +1,10 @@
+package com.golfRental.domain.category.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CategoryUpdateResponse(
+        Long categoryId,
+        String name
+) {
+}

--- a/src/main/java/com/golfRental/domain/category/entity/Category.java
+++ b/src/main/java/com/golfRental/domain/category/entity/Category.java
@@ -24,4 +24,8 @@ public class Category extends BaseEntity {
     private Category(String name) {
         this.name = name;
     }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/golfRental/domain/category/message/CategorySuccessMessage.java
+++ b/src/main/java/com/golfRental/domain/category/message/CategorySuccessMessage.java
@@ -5,8 +5,8 @@ public final class CategorySuccessMessage {
     public static final String CATEGORY_CREATED = "카테고리가 생성되었습니다.";
     public static final String CATEGORY_LIST_FETCHED = "카테고리 목록 조회에 성공하였습니다.";
     public static final String CATEGORY_GET_SUCCESS = "카테고리 상세 조회에 성공하였습니다.";
-    public final static String CATEGORY_UPDATED = "카테고리가 수정되었습니다.";
-    
+    public static final String CATEGORY_UPDATED = "카테고리가 수정되었습니다.";
+
     private CategorySuccessMessage() {
     }
 }

--- a/src/main/java/com/golfRental/domain/category/message/CategorySuccessMessage.java
+++ b/src/main/java/com/golfRental/domain/category/message/CategorySuccessMessage.java
@@ -5,7 +5,8 @@ public final class CategorySuccessMessage {
     public static final String CATEGORY_CREATED = "카테고리가 생성되었습니다.";
     public static final String CATEGORY_LIST_FETCHED = "카테고리 목록 조회에 성공하였습니다.";
     public static final String CATEGORY_GET_SUCCESS = "카테고리 상세 조회에 성공하였습니다.";
-
+    public final static String CATEGORY_UPDATED = "카테고리가 수정되었습니다.";
+    
     private CategorySuccessMessage() {
     }
 }

--- a/src/main/java/com/golfRental/domain/category/service/command/CategoryCommandService.java
+++ b/src/main/java/com/golfRental/domain/category/service/command/CategoryCommandService.java
@@ -1,9 +1,14 @@
 package com.golfRental.domain.category.service.command;
 
 import com.golfRental.domain.category.dto.request.CategoryCreateRequest;
+import com.golfRental.domain.category.dto.request.CategoryUpdateRequest;
 import com.golfRental.domain.category.dto.response.CategoryCreateResponse;
+import com.golfRental.domain.category.dto.response.CategoryUpdateResponse;
+
 
 public interface CategoryCommandService {
 
     CategoryCreateResponse createCategory(CategoryCreateRequest request);
+
+    CategoryUpdateResponse updateCategory(Long categoryId, CategoryUpdateRequest request);
 }

--- a/src/main/java/com/golfRental/domain/category/service/command/CategoryCommandServiceImpl.java
+++ b/src/main/java/com/golfRental/domain/category/service/command/CategoryCommandServiceImpl.java
@@ -43,15 +43,15 @@ public class CategoryCommandServiceImpl implements CategoryCommandService {
     @Override
     public CategoryUpdateResponse updateCategory(Long categoryId, CategoryUpdateRequest request) {
 
-        Category category = categoryRepository.findById(categoryId)
+        Category category = categoryRepository.findByIdAndDeletedAtIsNull(categoryId)
                 .orElseThrow(() -> new CategoryException(CategoryErrorCode.CATEGORY_NOT_FOUND));
 
-        boolean exists = categoryRepository.existsByNameAndNotDeleted(request.getName());
-        if (exists && !category.getName().equals(request.getName())) {
-            throw new CategoryException(CategoryErrorCode.CATEGORY_DUPLICATED_NAME);
+        if (!category.getName().equals(request.getName())) {
+            if (categoryRepository.existsByNameAndNotDeleted(request.getName())) {
+                throw new CategoryException(CategoryErrorCode.CATEGORY_DUPLICATED_NAME);
+            }
+            category.updateName(request.getName());
         }
-
-        category.updateName(request.getName());
 
         return CategoryUpdateResponse.builder()
                 .categoryId(category.getId())

--- a/src/main/java/com/golfRental/domain/category/service/command/CategoryCommandServiceImpl.java
+++ b/src/main/java/com/golfRental/domain/category/service/command/CategoryCommandServiceImpl.java
@@ -1,7 +1,9 @@
 package com.golfRental.domain.category.service.command;
 
 import com.golfRental.domain.category.dto.request.CategoryCreateRequest;
+import com.golfRental.domain.category.dto.request.CategoryUpdateRequest;
 import com.golfRental.domain.category.dto.response.CategoryCreateResponse;
+import com.golfRental.domain.category.dto.response.CategoryUpdateResponse;
 import com.golfRental.domain.category.entity.Category;
 import com.golfRental.domain.category.exception.CategoryErrorCode;
 import com.golfRental.domain.category.exception.CategoryException;
@@ -35,6 +37,25 @@ public class CategoryCommandServiceImpl implements CategoryCommandService {
         return CategoryCreateResponse.builder()
                 .categoryId(saved.getId())
                 .name(saved.getName())
+                .build();
+    }
+
+    @Override
+    public CategoryUpdateResponse updateCategory(Long categoryId, CategoryUpdateRequest request) {
+
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new CategoryException(CategoryErrorCode.CATEGORY_NOT_FOUND));
+
+        boolean exists = categoryRepository.existsByNameAndNotDeleted(request.getName());
+        if (exists && !category.getName().equals(request.getName())) {
+            throw new CategoryException(CategoryErrorCode.CATEGORY_DUPLICATED_NAME);
+        }
+
+        category.updateName(request.getName());
+
+        return CategoryUpdateResponse.builder()
+                .categoryId(category.getId())
+                .name(category.getName())
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 -->

- Closes #58
- 관리자가 특정 카테고리 이름을 수정할 수 있는 API를 구현

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- CategoryUpdateRequest DTO 추가
- CategoryUpdateResponse DTO 생성 
- CategoryCommandService / CategoryCommandServiceImpl 수정 기능 추가
- 카테고리 수정 시 기존 이름 중복 여부 검증
- 엔티티의 updateName() 메서드 활용하여 이름 변경 적용
- API 엔드포인트: PUT /api/v1/admin/categories/{categoryId}
- 관리자 권한(@PreAuthorize(“hasRole(‘ADMIN’)”)) 적용

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성
