### PR TITLE
feat: Implement category delete API

### DIFF
--- a/src/main/java/com/golfRental/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/golfRental/domain/category/controller/CategoryController.java
@@ -49,4 +49,12 @@ public interface CategoryController {
     ResponseEntity<CommonApiResponse<CategoryUpdateResponse>>
     updateCategory(Long categoryId, CategoryUpdateRequest categoryUpdateRequest);
 
+    /**
+     * 카테고리 삭제 API (관리자 전용)
+     *
+     * @param categoryId 삭제할 카테고리 ID
+     * @return void
+     */
+    ResponseEntity<CommonApiResponse<Void>>
+    deleteCategory(Long categoryId);
 }

--- a/src/main/java/com/golfRental/domain/category/controller/CategoryControllerImpl.java
+++ b/src/main/java/com/golfRental/domain/category/controller/CategoryControllerImpl.java
@@ -88,8 +88,7 @@ public class CategoryControllerImpl implements CategoryController {
     ) {
         categoryCommandService.deleteCategory(categoryId);
 
-        return CommonApiResponse.success(
-                null,
+        return CommonApiResponse.deleteSuccess(
                 CategorySuccessMessage.CATEGORY_DELETED
         );
     }

--- a/src/main/java/com/golfRental/domain/category/controller/CategoryControllerImpl.java
+++ b/src/main/java/com/golfRental/domain/category/controller/CategoryControllerImpl.java
@@ -79,4 +79,18 @@ public class CategoryControllerImpl implements CategoryController {
                 CategorySuccessMessage.CATEGORY_UPDATED
         );
     }
+
+    @Override
+    @DeleteMapping("/admin/categories/{categoryId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<CommonApiResponse<Void>> deleteCategory(
+            @PathVariable Long categoryId
+    ) {
+        categoryCommandService.deleteCategory(categoryId);
+
+        return CommonApiResponse.success(
+                null,
+                CategorySuccessMessage.CATEGORY_DELETED
+        );
+    }
 }

--- a/src/main/java/com/golfRental/domain/category/entity/Category.java
+++ b/src/main/java/com/golfRental/domain/category/entity/Category.java
@@ -28,4 +28,8 @@ public class Category extends BaseEntity {
     public void updateName(String name) {
         this.name = name;
     }
+
+    public void softDelete() {
+        this.delete();
+    }
 }

--- a/src/main/java/com/golfRental/domain/category/message/CategorySuccessMessage.java
+++ b/src/main/java/com/golfRental/domain/category/message/CategorySuccessMessage.java
@@ -6,6 +6,7 @@ public final class CategorySuccessMessage {
     public static final String CATEGORY_LIST_FETCHED = "카테고리 목록 조회에 성공하였습니다.";
     public static final String CATEGORY_GET_SUCCESS = "카테고리 상세 조회에 성공하였습니다.";
     public static final String CATEGORY_UPDATED = "카테고리가 수정되었습니다.";
+    public static final String CATEGORY_DELETED = "카테고리를 삭제했습니다.";
 
     private CategorySuccessMessage() {
     }

--- a/src/main/java/com/golfRental/domain/category/service/command/CategoryCommandService.java
+++ b/src/main/java/com/golfRental/domain/category/service/command/CategoryCommandService.java
@@ -11,4 +11,6 @@ public interface CategoryCommandService {
     CategoryCreateResponse createCategory(CategoryCreateRequest request);
 
     CategoryUpdateResponse updateCategory(Long categoryId, CategoryUpdateRequest request);
+
+    void deleteCategory(Long categoryId);
 }

--- a/src/main/java/com/golfRental/domain/category/service/command/CategoryCommandServiceImpl.java
+++ b/src/main/java/com/golfRental/domain/category/service/command/CategoryCommandServiceImpl.java
@@ -58,4 +58,13 @@ public class CategoryCommandServiceImpl implements CategoryCommandService {
                 .name(category.getName())
                 .build();
     }
+
+    @Override
+    public void deleteCategory(Long categoryId) {
+
+        Category category = categoryRepository.findByIdAndDeletedAtIsNull(categoryId)
+                .orElseThrow(() -> new CategoryException(CategoryErrorCode.CATEGORY_NOT_FOUND));
+
+        category.softDelete();
+    }
 }


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 -->

- Closes #59
- 관리자가 카테고리를 삭제할 수 있는 Soft Delete 방식의 API를 구현

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- DELETE /api/v1/admin/categories/{categoryId} 엔드포인트 추가
- CategoryController / Impl에 삭제 메서드 구현
- CategoryCommandService / Impl에 soft delete 로직 추가
- Category 엔티티의 delete() 메서드 활용하여 deletedAt 값 설정
- 일반 조회(findAllByDeletedAtIsNull, findByIdAndDeletedAtIsNull)에서 삭제된 카테고리는 자동 제외
- 관리자 권한(@PreAuthorize("hasRole('ADMIN'))) 적용
- 삭제 성공 메시지 `CATEGORY_DELETED` 추가

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성
