### PR TITLE
refactor: remove duplicated reservation query logic

### DIFF
--- a/src/main/java/com/golfRental/domain/reservation/service/query/ReservationQueryServiceImpl.java
+++ b/src/main/java/com/golfRental/domain/reservation/service/query/ReservationQueryServiceImpl.java
@@ -17,12 +17,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReservationQueryServiceImpl implements ReservationQueryService {
 
     private final ReservationRepository reservationRepository;
-
+    
     @Override
     public ReservationGetResponse findById(Long reservationId, Long currentUserId) {
 
-        Reservation reservation = reservationRepository.findByIdWithDetails(reservationId)
-                .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+        Reservation reservation = getReservationOrThrow(reservationId);
 
         // 권한 검증
         if (!reservation.getHostUser().getId().equals(currentUserId) &&
@@ -45,6 +44,10 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
 
     @Override
     public Reservation findById(Long reservationId) {
+        return getReservationOrThrow(reservationId);
+    }
+
+    private Reservation getReservationOrThrow(Long reservationId) {
         return reservationRepository.findByIdWithDetails(reservationId)
                 .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
     }


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 -->

- Closes #85 
- ReservationQueryServiceImpl 내부에서 예약 엔티티 조회 로직이 중복되는 문제를 개선하기 위해, 공통 조회 메서드를 분리하여 리팩토링

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 예약 조회 로직 중복 제거
-  공통 메서드 추가(private Reservation getReservationOrThrow(Long id))

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성
