### PR TITLE
feat: Implement reservation list retrieval API

### DIFF
--- a/src/main/java/com/golfRental/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/golfRental/domain/reservation/controller/ReservationController.java
@@ -1,9 +1,11 @@
 package com.golfRental.domain.reservation.controller;
 
 import com.golfRental.common.response.CommonApiResponse;
+import com.golfRental.common.response.SliceResponse;
 import com.golfRental.domain.auth.dto.AuthUser;
 import com.golfRental.domain.reservation.dto.request.ReservationCreateRequest;
 import com.golfRental.domain.reservation.dto.response.ReservationCreateResponse;
+import com.golfRental.domain.reservation.dto.response.ReservationGetAllResponse;
 import com.golfRental.domain.reservation.dto.response.ReservationGetResponse;
 import org.springframework.http.ResponseEntity;
 
@@ -31,5 +33,19 @@ public interface ReservationController {
     ResponseEntity<CommonApiResponse<ReservationGetResponse>> getReservation(
             Long reservationId,
             AuthUser authUser
+    );
+
+    /**
+     * 사용자별 예약 목록 조회
+     *
+     * @param authUser
+     * @param page
+     * @param size
+     * @return SliceResponse<ReservationGetAllResponse>
+     */
+    ResponseEntity<CommonApiResponse<SliceResponse<ReservationGetAllResponse>>> getMyReservations(
+            AuthUser authUser,
+            int page,
+            int size
     );
 }

--- a/src/main/java/com/golfRental/domain/reservation/controller/ReservationControllerImpl.java
+++ b/src/main/java/com/golfRental/domain/reservation/controller/ReservationControllerImpl.java
@@ -1,9 +1,11 @@
 package com.golfRental.domain.reservation.controller;
 
 import com.golfRental.common.response.CommonApiResponse;
+import com.golfRental.common.response.SliceResponse;
 import com.golfRental.domain.auth.dto.AuthUser;
 import com.golfRental.domain.reservation.dto.request.ReservationCreateRequest;
 import com.golfRental.domain.reservation.dto.response.ReservationCreateResponse;
+import com.golfRental.domain.reservation.dto.response.ReservationGetAllResponse;
 import com.golfRental.domain.reservation.dto.response.ReservationGetResponse;
 import com.golfRental.domain.reservation.message.ReservationSuccessMessage;
 import com.golfRental.domain.reservation.service.command.ReservationCommandService;
@@ -51,6 +53,22 @@ public class ReservationControllerImpl implements ReservationController {
         return CommonApiResponse.success(
                 response,
                 ReservationSuccessMessage.GET_RESERVATION
+        );
+    }
+
+    @Override
+    @GetMapping("/me")
+    public ResponseEntity<CommonApiResponse<SliceResponse<ReservationGetAllResponse>>> getMyReservations(
+            @AuthenticationPrincipal AuthUser authUser,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        SliceResponse<ReservationGetAllResponse> response =
+                reservationQueryService.getMyReservations(authUser.getUserId(), page, size);
+
+        return CommonApiResponse.success(
+                response,
+                ReservationSuccessMessage.GET_RESERVATION_LIST
         );
     }
 }

--- a/src/main/java/com/golfRental/domain/reservation/dto/response/ReservationGetAllResponse.java
+++ b/src/main/java/com/golfRental/domain/reservation/dto/response/ReservationGetAllResponse.java
@@ -1,0 +1,20 @@
+package com.golfRental.domain.reservation.dto.response;
+
+import com.golfRental.domain.reservation.enums.ReservationStatus;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record ReservationGetAllResponse(
+        Long reservationId,
+        Long postId,
+        Long hostUserId,
+        Long guestUserId,
+        LocalDateTime reservationStartAt,
+        LocalDateTime reservationEndAt,
+        Integer price,
+        Integer deposit,
+        ReservationStatus status
+) {
+}

--- a/src/main/java/com/golfRental/domain/reservation/message/ReservationSuccessMessage.java
+++ b/src/main/java/com/golfRental/domain/reservation/message/ReservationSuccessMessage.java
@@ -4,6 +4,8 @@ public final class ReservationSuccessMessage {
 
     public final static String RESERVATION_CREATED = "예약을 요청을 생성하였습니다.";
     public final static String GET_RESERVATION = "예약 조회에 성공하였습니다.";
+    public final static String GET_RESERVATION_LIST = "사용자 예약 목록 조회에 성공하였습니다.";
+
 
     private ReservationSuccessMessage() {
     }

--- a/src/main/java/com/golfRental/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/golfRental/domain/reservation/repository/ReservationRepository.java
@@ -20,6 +20,9 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     Optional<Reservation> findByIdWithDetails(@Param("reservationId") Long reservationId);
 
     @Query("SELECT r FROM Reservation r " +
+            "JOIN FETCH r.post " +
+            "JOIN FETCH r.hostUser " +
+            "JOIN FETCH r.guestUser " +
             "WHERE (r.hostUser.id = :userId OR r.guestUser.id = :userId) " +
             "AND r.deletedAt IS NULL")
     Slice<Reservation> findMyReservations(

--- a/src/main/java/com/golfRental/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/golfRental/domain/reservation/repository/ReservationRepository.java
@@ -1,6 +1,8 @@
 package com.golfRental.domain.reservation.repository;
 
 import com.golfRental.domain.reservation.entity.Reservation;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,10 +12,18 @@ import java.util.Optional;
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
     @Query("SELECT r FROM Reservation r " +
-           "JOIN FETCH r.post " +
-           "JOIN FETCH r.hostUser " +
-           "JOIN FETCH r.guestUser " +
-           "WHERE r.id = :reservationId " +
-           "AND r.deletedAt IS NULL")
+            "JOIN FETCH r.post " +
+            "JOIN FETCH r.hostUser " +
+            "JOIN FETCH r.guestUser " +
+            "WHERE r.id = :reservationId " +
+            "AND r.deletedAt IS NULL")
     Optional<Reservation> findByIdWithDetails(@Param("reservationId") Long reservationId);
+
+    @Query("SELECT r FROM Reservation r " +
+            "WHERE (r.hostUser.id = :userId OR r.guestUser.id = :userId) " +
+            "AND r.deletedAt IS NULL")
+    Slice<Reservation> findMyReservations(
+            @Param("userId") Long userId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/golfRental/domain/reservation/service/query/ReservationQueryService.java
+++ b/src/main/java/com/golfRental/domain/reservation/service/query/ReservationQueryService.java
@@ -1,5 +1,7 @@
 package com.golfRental.domain.reservation.service.query;
 
+import com.golfRental.common.response.SliceResponse;
+import com.golfRental.domain.reservation.dto.response.ReservationGetAllResponse;
 import com.golfRental.domain.reservation.dto.response.ReservationGetResponse;
 import com.golfRental.domain.reservation.entity.Reservation;
 
@@ -8,4 +10,6 @@ public interface ReservationQueryService {
     ReservationGetResponse findById(Long reservationId, Long currentUserId);
 
     Reservation findById(Long reservationId);
+
+    SliceResponse<ReservationGetAllResponse> getMyReservations(Long userId, int page, int size);
 }

--- a/src/main/java/com/golfRental/domain/reservation/service/query/ReservationQueryServiceImpl.java
+++ b/src/main/java/com/golfRental/domain/reservation/service/query/ReservationQueryServiceImpl.java
@@ -1,5 +1,7 @@
 package com.golfRental.domain.reservation.service.query;
 
+import com.golfRental.common.response.SliceResponse;
+import com.golfRental.domain.reservation.dto.response.ReservationGetAllResponse;
 import com.golfRental.domain.reservation.dto.response.ReservationGetResponse;
 import com.golfRental.domain.reservation.entity.Reservation;
 import com.golfRental.domain.reservation.exception.ReservationErrorCode;
@@ -7,6 +9,9 @@ import com.golfRental.domain.reservation.exception.ReservationException;
 import com.golfRental.domain.reservation.repository.ReservationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,7 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReservationQueryServiceImpl implements ReservationQueryService {
 
     private final ReservationRepository reservationRepository;
-    
+
+    // 예약 상세 조회
     @Override
     public ReservationGetResponse findById(Long reservationId, Long currentUserId) {
 
@@ -42,13 +48,41 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
                 .build();
     }
 
+    // 예약 상세 조회 (내부용)
     @Override
     public Reservation findById(Long reservationId) {
         return getReservationOrThrow(reservationId);
     }
 
+    // 공통 조회 메서드
     private Reservation getReservationOrThrow(Long reservationId) {
         return reservationRepository.findByIdWithDetails(reservationId)
                 .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+    }
+
+    // 사용자별 예약 목록 조회
+    @Override
+    public SliceResponse<ReservationGetAllResponse> getMyReservations(Long userId, int page, int size) {
+
+        Pageable pageable = PageRequest.of(page, size);
+
+        Slice<Reservation> reservations =
+                reservationRepository.findMyReservations(userId, pageable);
+
+        Slice<ReservationGetAllResponse> contents = reservations.map(reservation ->
+                ReservationGetAllResponse.builder()
+                        .reservationId(reservation.getId())
+                        .postId(reservation.getPost().getId())
+                        .hostUserId(reservation.getHostUser().getId())
+                        .guestUserId(reservation.getGuestUser().getId())
+                        .reservationStartAt(reservation.getReservationStartAt())
+                        .reservationEndAt(reservation.getReservationEndAt())
+                        .price(reservation.getPrice())
+                        .deposit(reservation.getDeposit())
+                        .status(reservation.getStatus())
+                        .build()
+        );
+
+        return SliceResponse.fromSlice(contents);
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 -->

- Closes #89
- 로그인한 사용자 본인의 예약 목록을 조회하는 기능을 구현했습니다.

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- GET /api/v1/reservations/me
- ReservationGetAllResponse 생성
- ReservationQueryService#getMyReservations() 추가
- Slice 기반 페이징 응답 (SliceResponse) 적용
- Host / Guest 양쪽에 속한 예약 모두 조회

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성
