### PR TITLE
feat: Implement reservation approve API

### DIFF
--- a/src/main/java/com/golfRental/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/golfRental/domain/reservation/controller/ReservationController.java
@@ -7,6 +7,7 @@ import com.golfRental.domain.reservation.dto.request.ReservationCreateRequest;
 import com.golfRental.domain.reservation.dto.response.ReservationCreateResponse;
 import com.golfRental.domain.reservation.dto.response.ReservationGetAllResponse;
 import com.golfRental.domain.reservation.dto.response.ReservationGetResponse;
+import com.golfRental.domain.reservation.dto.response.ReservationUpdateStatusResponse;
 import org.springframework.http.ResponseEntity;
 
 public interface ReservationController {
@@ -38,14 +39,26 @@ public interface ReservationController {
     /**
      * 사용자별 예약 목록 조회
      *
-     * @param authUser
-     * @param page
-     * @param size
+     * @param authUser 로그인 사용자 정보
+     * @param page     페이지 번호
+     * @param size     페이지 크기
      * @return SliceResponse<ReservationGetAllResponse>
      */
     ResponseEntity<CommonApiResponse<SliceResponse<ReservationGetAllResponse>>> getMyReservations(
             AuthUser authUser,
             int page,
             int size
+    );
+
+    /**
+     * 예약 승인
+     *
+     * @param reservationId 승인할 예약 ID
+     * @param authUser      로그인 사용자 정보
+     * @return ReservationUpdateStatusResponse
+     */
+    ResponseEntity<CommonApiResponse<ReservationUpdateStatusResponse>> approveReservation(
+            Long reservationId,
+            AuthUser authUser
     );
 }

--- a/src/main/java/com/golfRental/domain/reservation/controller/ReservationControllerImpl.java
+++ b/src/main/java/com/golfRental/domain/reservation/controller/ReservationControllerImpl.java
@@ -7,6 +7,7 @@ import com.golfRental.domain.reservation.dto.request.ReservationCreateRequest;
 import com.golfRental.domain.reservation.dto.response.ReservationCreateResponse;
 import com.golfRental.domain.reservation.dto.response.ReservationGetAllResponse;
 import com.golfRental.domain.reservation.dto.response.ReservationGetResponse;
+import com.golfRental.domain.reservation.dto.response.ReservationUpdateStatusResponse;
 import com.golfRental.domain.reservation.message.ReservationSuccessMessage;
 import com.golfRental.domain.reservation.service.command.ReservationCommandService;
 import com.golfRental.domain.reservation.service.query.ReservationQueryService;
@@ -69,6 +70,21 @@ public class ReservationControllerImpl implements ReservationController {
         return CommonApiResponse.success(
                 response,
                 ReservationSuccessMessage.GET_RESERVATION_LIST
+        );
+    }
+
+    @Override
+    @PatchMapping("/{reservationId}/approve")
+    public ResponseEntity<CommonApiResponse<ReservationUpdateStatusResponse>> approveReservation(
+            @PathVariable Long reservationId,
+            @RequestAttribute("authUser") AuthUser authUser
+    ) {
+        ReservationUpdateStatusResponse response =
+                reservationCommandService.approveReservation(reservationId, authUser.getUserId());
+
+        return CommonApiResponse.success(
+                response,
+                ReservationSuccessMessage.RESERVATION_APPROVED
         );
     }
 }

--- a/src/main/java/com/golfRental/domain/reservation/controller/ReservationControllerImpl.java
+++ b/src/main/java/com/golfRental/domain/reservation/controller/ReservationControllerImpl.java
@@ -77,7 +77,7 @@ public class ReservationControllerImpl implements ReservationController {
     @PatchMapping("/{reservationId}/approve")
     public ResponseEntity<CommonApiResponse<ReservationUpdateStatusResponse>> approveReservation(
             @PathVariable Long reservationId,
-            @RequestAttribute("authUser") AuthUser authUser
+            @AuthenticationPrincipal AuthUser authUser
     ) {
         ReservationUpdateStatusResponse response =
                 reservationCommandService.approveReservation(reservationId, authUser.getUserId());

--- a/src/main/java/com/golfRental/domain/reservation/dto/response/ReservationUpdateStatusResponse.java
+++ b/src/main/java/com/golfRental/domain/reservation/dto/response/ReservationUpdateStatusResponse.java
@@ -1,0 +1,11 @@
+package com.golfRental.domain.reservation.dto.response;
+
+import com.golfRental.domain.reservation.enums.ReservationStatus;
+import lombok.Builder;
+
+@Builder
+public record ReservationUpdateStatusResponse(
+        Long reservationId,
+        ReservationStatus status
+) {
+}

--- a/src/main/java/com/golfRental/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/golfRental/domain/reservation/entity/Reservation.java
@@ -3,6 +3,8 @@ package com.golfRental.domain.reservation.entity;
 import com.golfRental.common.entity.BaseEntity;
 import com.golfRental.domain.post.entity.Post;
 import com.golfRental.domain.reservation.enums.ReservationStatus;
+import com.golfRental.domain.reservation.exception.ReservationErrorCode;
+import com.golfRental.domain.reservation.exception.ReservationException;
 import com.golfRental.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -51,7 +53,15 @@ public class Reservation extends BaseEntity {
     private User guestUser;
 
     @Builder
-    private Reservation(LocalDateTime reservationStartAt, LocalDateTime reservationEndAt, Integer price, Integer deposit, ReservationStatus status, Post post, User hostUser, User guestUser) {
+    private Reservation(LocalDateTime reservationStartAt,
+                        LocalDateTime reservationEndAt,
+                        Integer price,
+                        Integer deposit,
+                        ReservationStatus status,
+                        Post post,
+                        User hostUser,
+                        User guestUser) {
+
         this.reservationStartAt = reservationStartAt;
         this.reservationEndAt = reservationEndAt;
         this.price = price;
@@ -62,7 +72,20 @@ public class Reservation extends BaseEntity {
         this.guestUser = guestUser;
     }
 
-    public void updateStatus(ReservationStatus status) {
+    // 예약 승인 도메인 규칙
+    public void approve() {
+        if (this.status == ReservationStatus.APPROVED) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_APPROVED);
+        }
+
+        if (this.status != ReservationStatus.REQUESTED) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_CANNOT_APPROVE);
+        }
+
+        this.status = ReservationStatus.APPROVED;
+    }
+
+    private void updateStatus(ReservationStatus status) {
         this.status = status;
     }
 }

--- a/src/main/java/com/golfRental/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/golfRental/domain/reservation/entity/Reservation.java
@@ -61,4 +61,8 @@ public class Reservation extends BaseEntity {
         this.hostUser = hostUser;
         this.guestUser = guestUser;
     }
+
+    public void updateStatus(ReservationStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/golfRental/domain/reservation/exception/ReservationErrorCode.java
+++ b/src/main/java/com/golfRental/domain/reservation/exception/ReservationErrorCode.java
@@ -10,7 +10,10 @@ import org.springframework.http.HttpStatus;
 public enum ReservationErrorCode implements ErrorCode {
 
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "예약 정보를 찾을 수 없습니다."),
-    RESERVATION_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 예약에 접근할 수 없습니다.");
+    RESERVATION_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 예약에 접근할 수 없습니다."),
+    RESERVATION_ALREADY_APPROVED(HttpStatus.BAD_REQUEST, "이미 승인된 예약입니다."),
+    RESERVATION_CANNOT_APPROVE(HttpStatus.BAD_REQUEST, "이 상태에서는 예약 승인할 수 없습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/golfRental/domain/reservation/message/ReservationSuccessMessage.java
+++ b/src/main/java/com/golfRental/domain/reservation/message/ReservationSuccessMessage.java
@@ -5,7 +5,7 @@ public final class ReservationSuccessMessage {
     public final static String RESERVATION_CREATED = "예약을 요청을 생성하였습니다.";
     public final static String GET_RESERVATION = "예약 조회에 성공하였습니다.";
     public final static String GET_RESERVATION_LIST = "사용자 예약 목록 조회에 성공하였습니다.";
-
+    public final static String RESERVATION_APPROVED = "예약이 승인되었습니다.";
 
     private ReservationSuccessMessage() {
     }

--- a/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandService.java
+++ b/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandService.java
@@ -2,8 +2,11 @@ package com.golfRental.domain.reservation.service.command;
 
 import com.golfRental.domain.reservation.dto.request.ReservationCreateRequest;
 import com.golfRental.domain.reservation.dto.response.ReservationCreateResponse;
+import com.golfRental.domain.reservation.dto.response.ReservationUpdateStatusResponse;
 
 public interface ReservationCommandService {
 
     ReservationCreateResponse createReservation(ReservationCreateRequest reservationCreateRequest, Long userId);
+
+    ReservationUpdateStatusResponse approveReservation(Long reservationId, Long userId);
 }

--- a/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandServiceImpl.java
+++ b/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandServiceImpl.java
@@ -49,9 +49,9 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
 
         return ReservationCreateResponse.builder()
                 .reservationId(saved.getId())
-                .postId(post.getId())
-                .hostUserId(hostUser.getId())
-                .guestUserId(guestUser.getId())
+                .postId(saved.getPost().getId())
+                .hostUserId(saved.getHostUser().getId())
+                .guestUserId(saved.getGuestUser().getId())
                 .reservationStartAt(saved.getReservationStartAt())
                 .reservationEndAt(saved.getReservationEndAt())
                 .price(saved.getPrice())
@@ -71,17 +71,8 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
             throw new ReservationException(ReservationErrorCode.RESERVATION_FORBIDDEN);
         }
 
-        // 상태 검증
-        if (reservation.getStatus() == ReservationStatus.APPROVED) {
-            throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_APPROVED);
-        }
-
-        if (reservation.getStatus() != ReservationStatus.REQUESTED) {
-            throw new ReservationException(ReservationErrorCode.RESERVATION_CANNOT_APPROVE);
-        }
-
-        // 승인 처리
-        reservation.updateStatus(ReservationStatus.APPROVED);
+        // 엔티티에게 승인 명령 (도메인 규칙 포함)
+        reservation.approve();
 
         return ReservationUpdateStatusResponse.builder()
                 .reservationId(reservation.getId())

--- a/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandServiceImpl.java
+++ b/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandServiceImpl.java
@@ -4,8 +4,11 @@ import com.golfRental.domain.post.entity.Post;
 import com.golfRental.domain.post.service.query.PostQueryService;
 import com.golfRental.domain.reservation.dto.request.ReservationCreateRequest;
 import com.golfRental.domain.reservation.dto.response.ReservationCreateResponse;
+import com.golfRental.domain.reservation.dto.response.ReservationUpdateStatusResponse;
 import com.golfRental.domain.reservation.entity.Reservation;
 import com.golfRental.domain.reservation.enums.ReservationStatus;
+import com.golfRental.domain.reservation.exception.ReservationErrorCode;
+import com.golfRental.domain.reservation.exception.ReservationException;
 import com.golfRental.domain.reservation.repository.ReservationRepository;
 import com.golfRental.domain.user.entity.User;
 import com.golfRental.domain.user.service.query.UserQueryService;
@@ -54,6 +57,35 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
                 .price(saved.getPrice())
                 .deposit(saved.getDeposit())
                 .status(saved.getStatus())
+                .build();
+    }
+
+    @Override
+    public ReservationUpdateStatusResponse approveReservation(Long reservationId, Long userId) {
+
+        Reservation reservation = reservationRepository.findByIdWithDetails(reservationId)
+                .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+
+        // 호스트 권한 검증
+        if (!reservation.getHostUser().getId().equals(userId)) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_FORBIDDEN);
+        }
+
+        // 상태 검증
+        if (reservation.getStatus() == ReservationStatus.APPROVED) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_APPROVED);
+        }
+
+        if (reservation.getStatus() != ReservationStatus.REQUESTED) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_CANNOT_APPROVE);
+        }
+
+        // 승인 처리
+        reservation.updateStatus(ReservationStatus.APPROVED);
+
+        return ReservationUpdateStatusResponse.builder()
+                .reservationId(reservation.getId())
+                .status(reservation.getStatus())
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 -->

- Closes #90
- 호스트 사용자가 예약 요청을 승인할 수 있는 예약 승인 API를 구현


## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- ReservationUpdateStatusResponse DTO 추가
- ReservationController / Impl에 예약 승인 엔드포인트 추가
  - PATCH /api/v1/reservations/{reservationId}/approve
- ReservationCommandService / Impl에 approveReservation 비즈니스 로직 구현
  - 호스트 사용자 권한 검증
  - ReservationStatus.REQUESTED → APPROVED 상태 변경
  - 이미 처리된 예약에 대한 상태 변경 방지 로직 추가
- ReservationSuccessMessage에 예약 승인 성공 메시지 상수 추가

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성
