### PR TITLE
feat: Implement reservation rejection API

### DIFF
--- a/src/main/java/com/golfRental/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/golfRental/domain/reservation/controller/ReservationController.java
@@ -61,4 +61,16 @@ public interface ReservationController {
             Long reservationId,
             AuthUser authUser
     );
+
+    /**
+     * 예약 거절
+     *
+     * @param reservationId 거절할 예약 ID
+     * @param authUser      로그인 사용자 정보
+     * @return ReservationUpdateStatusResponse
+     */
+    ResponseEntity<CommonApiResponse<ReservationUpdateStatusResponse>> rejectReservation(
+            Long reservationId,
+            AuthUser authUser
+    );
 }

--- a/src/main/java/com/golfRental/domain/reservation/controller/ReservationControllerImpl.java
+++ b/src/main/java/com/golfRental/domain/reservation/controller/ReservationControllerImpl.java
@@ -87,4 +87,19 @@ public class ReservationControllerImpl implements ReservationController {
                 ReservationSuccessMessage.RESERVATION_APPROVED
         );
     }
+
+    @Override
+    @PatchMapping("/{reservationId}/reject")
+    public ResponseEntity<CommonApiResponse<ReservationUpdateStatusResponse>> rejectReservation(
+            @PathVariable Long reservationId,
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+        ReservationUpdateStatusResponse response =
+                reservationCommandService.rejectReservation(reservationId, authUser.getUserId());
+
+        return CommonApiResponse.success(
+                response,
+                ReservationSuccessMessage.RESERVATION_REJECTED
+        );
+    }
 }

--- a/src/main/java/com/golfRental/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/golfRental/domain/reservation/entity/Reservation.java
@@ -72,7 +72,7 @@ public class Reservation extends BaseEntity {
         this.guestUser = guestUser;
     }
 
-    // 예약 승인 도메인 규칙
+    // 예약 승인
     public void approve() {
         if (this.status == ReservationStatus.APPROVED) {
             throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_APPROVED);
@@ -85,7 +85,17 @@ public class Reservation extends BaseEntity {
         this.status = ReservationStatus.APPROVED;
     }
 
-    private void updateStatus(ReservationStatus status) {
-        this.status = status;
+    // 예약 거절
+    public void reject() {
+
+        if (status == ReservationStatus.REJECTED) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_REJECTED);
+        }
+
+        if (status != ReservationStatus.REQUESTED) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_CANNOT_REJECT);
+        }
+
+        this.status = ReservationStatus.REJECTED;
     }
 }

--- a/src/main/java/com/golfRental/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/golfRental/domain/reservation/entity/Reservation.java
@@ -88,11 +88,12 @@ public class Reservation extends BaseEntity {
     // 예약 거절
     public void reject() {
 
-        if (status == ReservationStatus.REJECTED) {
-            throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_REJECTED);
-        }
+        if (this.status != ReservationStatus.REQUESTED) {
 
-        if (status != ReservationStatus.REQUESTED) {
+            if (this.status == ReservationStatus.REJECTED) {
+                throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_REJECTED);
+            }
+
             throw new ReservationException(ReservationErrorCode.RESERVATION_CANNOT_REJECT);
         }
 

--- a/src/main/java/com/golfRental/domain/reservation/exception/ReservationErrorCode.java
+++ b/src/main/java/com/golfRental/domain/reservation/exception/ReservationErrorCode.java
@@ -12,8 +12,9 @@ public enum ReservationErrorCode implements ErrorCode {
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "예약 정보를 찾을 수 없습니다."),
     RESERVATION_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 예약에 접근할 수 없습니다."),
     RESERVATION_ALREADY_APPROVED(HttpStatus.BAD_REQUEST, "이미 승인된 예약입니다."),
-    RESERVATION_CANNOT_APPROVE(HttpStatus.BAD_REQUEST, "이 상태에서는 예약 승인할 수 없습니다.");
-
+    RESERVATION_CANNOT_APPROVE(HttpStatus.BAD_REQUEST, "이 상태에서는 예약 승인할 수 없습니다."),
+    RESERVATION_ALREADY_REJECTED(HttpStatus.BAD_REQUEST, "이미 거절된 예약입니다."),
+    RESERVATION_CANNOT_REJECT(HttpStatus.BAD_REQUEST, "이 상태에서는 예약을 거절할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/golfRental/domain/reservation/message/ReservationSuccessMessage.java
+++ b/src/main/java/com/golfRental/domain/reservation/message/ReservationSuccessMessage.java
@@ -6,6 +6,7 @@ public final class ReservationSuccessMessage {
     public final static String GET_RESERVATION = "예약 조회에 성공하였습니다.";
     public final static String GET_RESERVATION_LIST = "사용자 예약 목록 조회에 성공하였습니다.";
     public final static String RESERVATION_APPROVED = "예약이 승인되었습니다.";
+    public final static String RESERVATION_REJECTED = "예약이 거절되었습니다.";
 
     private ReservationSuccessMessage() {
     }

--- a/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandService.java
+++ b/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandService.java
@@ -9,4 +9,6 @@ public interface ReservationCommandService {
     ReservationCreateResponse createReservation(ReservationCreateRequest reservationCreateRequest, Long userId);
 
     ReservationUpdateStatusResponse approveReservation(Long reservationId, Long userId);
+
+    ReservationUpdateStatusResponse rejectReservation(Long reservationId, Long userId);
 }

--- a/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandServiceImpl.java
+++ b/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandServiceImpl.java
@@ -79,4 +79,24 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
                 .status(reservation.getStatus())
                 .build();
     }
+
+    @Override
+    public ReservationUpdateStatusResponse rejectReservation(Long reservationId, Long userId) {
+
+        Reservation reservation = reservationRepository.findByIdWithDetails(reservationId)
+                .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+
+        // 권한 검증(호스트만 가능)
+        if (!reservation.getHostUser().getId().equals(userId)) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_FORBIDDEN);
+        }
+
+        // 도메인 메서드에 상태 전이 위임
+        reservation.reject();
+
+        return ReservationUpdateStatusResponse.builder()
+                .reservationId(reservation.getId())
+                .status(reservation.getStatus())
+                .build();
+    }
 }

--- a/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandServiceImpl.java
+++ b/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandServiceImpl.java
@@ -63,15 +63,9 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
     @Override
     public ReservationUpdateStatusResponse approveReservation(Long reservationId, Long userId) {
 
-        Reservation reservation = reservationRepository.findByIdWithDetails(reservationId)
-                .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+        Reservation reservation = findReservationAndVerifyHost(reservationId, userId);
 
-        // 호스트 권한 검증
-        if (!reservation.getHostUser().getId().equals(userId)) {
-            throw new ReservationException(ReservationErrorCode.RESERVATION_FORBIDDEN);
-        }
-
-        // 엔티티에게 승인 명령 (도메인 규칙 포함)
+        // 엔티티에게 승인 명령
         reservation.approve();
 
         return ReservationUpdateStatusResponse.builder()
@@ -83,20 +77,27 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
     @Override
     public ReservationUpdateStatusResponse rejectReservation(Long reservationId, Long userId) {
 
-        Reservation reservation = reservationRepository.findByIdWithDetails(reservationId)
-                .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+        Reservation reservation = findReservationAndVerifyHost(reservationId, userId);
 
-        // 권한 검증(호스트만 가능)
-        if (!reservation.getHostUser().getId().equals(userId)) {
-            throw new ReservationException(ReservationErrorCode.RESERVATION_FORBIDDEN);
-        }
-
-        // 도메인 메서드에 상태 전이 위임
+        // 엔티티에게 거절 명령
         reservation.reject();
 
         return ReservationUpdateStatusResponse.builder()
                 .reservationId(reservation.getId())
                 .status(reservation.getStatus())
                 .build();
+    }
+
+    // 공통: 예약 조회 + 호스트 권한 검증
+    private Reservation findReservationAndVerifyHost(Long reservationId, Long userId) {
+
+        Reservation reservation = reservationRepository.findByIdWithDetails(reservationId)
+                .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+
+        if (!reservation.getHostUser().getId().equals(userId)) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_FORBIDDEN);
+        }
+
+        return reservation;
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 -->

- Closes #91
- 호스트가 예약 요청을 거절하는 기능을 추가


## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 예약 상태 REQUESTED → REJECTED 변경
- Reservation 엔티티에 reject() 도메인 메서드 추가 (상태 전이 캡슐화)
- 승인/거절 관련 에러코드 추가 (RESERVATION_ALREADY_REJECTED, RESERVATION_CANNOT_REJECT)
- 호스트 권한 검증 추가

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성
