### PR TITLE
feat: Implement reservation cancel API

### DIFF
--- a/src/main/java/com/golfRental/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/golfRental/domain/reservation/controller/ReservationController.java
@@ -42,7 +42,7 @@ public interface ReservationController {
      * @param authUser 로그인 사용자 정보
      * @param page     페이지 번호
      * @param size     페이지 크기
-     * @return SliceResponse<ReservationGetAllResponse>
+     * @return ResponseEntity<CommonApiResponse < SliceResponse < ReservationGetAllResponse>>>
      */
     ResponseEntity<CommonApiResponse<SliceResponse<ReservationGetAllResponse>>> getMyReservations(
             AuthUser authUser,
@@ -55,7 +55,7 @@ public interface ReservationController {
      *
      * @param reservationId 승인할 예약 ID
      * @param authUser      로그인 사용자 정보
-     * @return ReservationUpdateStatusResponse
+     * @return ResponseEntity<CommonApiResponse < ReservationUpdateStatusResponse>>
      */
     ResponseEntity<CommonApiResponse<ReservationUpdateStatusResponse>> approveReservation(
             Long reservationId,
@@ -67,9 +67,21 @@ public interface ReservationController {
      *
      * @param reservationId 거절할 예약 ID
      * @param authUser      로그인 사용자 정보
-     * @return ReservationUpdateStatusResponse
+     * @return ResponseEntity<CommonApiResponse < ReservationUpdateStatusResponse>>
      */
     ResponseEntity<CommonApiResponse<ReservationUpdateStatusResponse>> rejectReservation(
+            Long reservationId,
+            AuthUser authUser
+    );
+
+    /**
+     * 예약 취소
+     *
+     * @param reservationId 취소할 예약 ID
+     * @param authUser      로그인 사용자 정보
+     * @return ResponseEntity<CommonApiResponse < ReservationUpdateStatusResponse>>
+     */
+    ResponseEntity<CommonApiResponse<ReservationUpdateStatusResponse>> cancelReservation(
             Long reservationId,
             AuthUser authUser
     );

--- a/src/main/java/com/golfRental/domain/reservation/controller/ReservationControllerImpl.java
+++ b/src/main/java/com/golfRental/domain/reservation/controller/ReservationControllerImpl.java
@@ -102,4 +102,19 @@ public class ReservationControllerImpl implements ReservationController {
                 ReservationSuccessMessage.RESERVATION_REJECTED
         );
     }
+
+    @Override
+    @PatchMapping("/{reservationId}/cancel")
+    public ResponseEntity<CommonApiResponse<ReservationUpdateStatusResponse>> cancelReservation(
+            @PathVariable Long reservationId,
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+        ReservationUpdateStatusResponse response =
+                reservationCommandService.cancelReservation(reservationId, authUser.getUserId());
+
+        return CommonApiResponse.success(
+                response,
+                ReservationSuccessMessage.RESERVATION_CANCELLED
+        );
+    }
 }

--- a/src/main/java/com/golfRental/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/golfRental/domain/reservation/entity/Reservation.java
@@ -99,4 +99,21 @@ public class Reservation extends BaseEntity {
 
         this.status = ReservationStatus.REJECTED;
     }
+
+    // 예약 취소
+    public void cancel() {
+
+        // 이미 취소된 경우
+        if (this.status == ReservationStatus.CANCELLED) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_CANCELLED);
+        }
+
+        // 취소가 허용되지 않는 상태
+        if (this.status != ReservationStatus.REQUESTED &&
+                this.status != ReservationStatus.APPROVED) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_CANNOT_CANCEL);
+        }
+
+        this.status = ReservationStatus.CANCELLED;
+    }
 }

--- a/src/main/java/com/golfRental/domain/reservation/exception/ReservationErrorCode.java
+++ b/src/main/java/com/golfRental/domain/reservation/exception/ReservationErrorCode.java
@@ -14,7 +14,9 @@ public enum ReservationErrorCode implements ErrorCode {
     RESERVATION_ALREADY_APPROVED(HttpStatus.BAD_REQUEST, "이미 승인된 예약입니다."),
     RESERVATION_CANNOT_APPROVE(HttpStatus.BAD_REQUEST, "이 상태에서는 예약 승인할 수 없습니다."),
     RESERVATION_ALREADY_REJECTED(HttpStatus.BAD_REQUEST, "이미 거절된 예약입니다."),
-    RESERVATION_CANNOT_REJECT(HttpStatus.BAD_REQUEST, "이 상태에서는 예약을 거절할 수 없습니다.");
+    RESERVATION_CANNOT_REJECT(HttpStatus.BAD_REQUEST, "이 상태에서는 예약을 거절할 수 없습니다."),
+    RESERVATION_ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "이미 취소된 예약입니다."),
+    RESERVATION_CANNOT_CANCEL(HttpStatus.BAD_REQUEST, "이 상태에서는 예약을 취소할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/golfRental/domain/reservation/message/ReservationSuccessMessage.java
+++ b/src/main/java/com/golfRental/domain/reservation/message/ReservationSuccessMessage.java
@@ -7,6 +7,7 @@ public final class ReservationSuccessMessage {
     public final static String GET_RESERVATION_LIST = "사용자 예약 목록 조회에 성공하였습니다.";
     public final static String RESERVATION_APPROVED = "예약이 승인되었습니다.";
     public final static String RESERVATION_REJECTED = "예약이 거절되었습니다.";
+    public final static String RESERVATION_CANCELLED = "예약이 취소되었습니다.";
 
     private ReservationSuccessMessage() {
     }

--- a/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandService.java
+++ b/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandService.java
@@ -11,4 +11,6 @@ public interface ReservationCommandService {
     ReservationUpdateStatusResponse approveReservation(Long reservationId, Long userId);
 
     ReservationUpdateStatusResponse rejectReservation(Long reservationId, Long userId);
+
+    ReservationUpdateStatusResponse cancelReservation(Long reservationId, Long userId);
 }

--- a/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandServiceImpl.java
+++ b/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandServiceImpl.java
@@ -27,6 +27,7 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
     private final PostQueryService postQueryService;
     private final UserQueryService userQueryService;
 
+    // 예약 생성
     @Override
     public ReservationCreateResponse createReservation(ReservationCreateRequest request, Long userId) {
 
@@ -60,13 +61,13 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
                 .build();
     }
 
+    // 승인
     @Override
     public ReservationUpdateStatusResponse approveReservation(Long reservationId, Long userId) {
 
         Reservation reservation = findReservationAndVerifyHost(reservationId, userId);
 
-        // 엔티티에게 승인 명령
-        reservation.approve();
+        reservation.approve(); // 엔티티 도메인 규칙 실행
 
         return ReservationUpdateStatusResponse.builder()
                 .reservationId(reservation.getId())
@@ -74,13 +75,13 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
                 .build();
     }
 
+    // 거절
     @Override
     public ReservationUpdateStatusResponse rejectReservation(Long reservationId, Long userId) {
 
         Reservation reservation = findReservationAndVerifyHost(reservationId, userId);
 
-        // 엔티티에게 거절 명령
-        reservation.reject();
+        reservation.reject(); // 엔티티 도메인 규칙 실행
 
         return ReservationUpdateStatusResponse.builder()
                 .reservationId(reservation.getId())
@@ -88,11 +89,32 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
                 .build();
     }
 
-    // 공통: 예약 조회 + 호스트 권한 검증
+    // 취소
+    @Override
+    public ReservationUpdateStatusResponse cancelReservation(Long reservationId, Long userId) {
+
+        Reservation reservation = findReservationAndVerifyGuest(reservationId, userId);
+
+        reservation.cancel(); // 엔티티 도메인 규칙 실행
+
+        return ReservationUpdateStatusResponse.builder()
+                .reservationId(reservation.getId())
+                .status(reservation.getStatus())
+                .build();
+    }
+
+    // 공통 조회 메서드
+    private Reservation findReservationById(Long reservationId) {
+        return reservationRepository.findByIdWithDetails(reservationId)
+                .orElseThrow(() ->
+                        new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND)
+                );
+    }
+
+    // 호스트 검증
     private Reservation findReservationAndVerifyHost(Long reservationId, Long userId) {
 
-        Reservation reservation = reservationRepository.findByIdWithDetails(reservationId)
-                .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+        Reservation reservation = findReservationById(reservationId);
 
         if (!reservation.getHostUser().getId().equals(userId)) {
             throw new ReservationException(ReservationErrorCode.RESERVATION_FORBIDDEN);
@@ -101,23 +123,15 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
         return reservation;
     }
 
-    @Override
-    public ReservationUpdateStatusResponse cancelReservation(Long reservationId, Long userId) {
+    // 게스트 검증
+    private Reservation findReservationAndVerifyGuest(Long reservationId, Long userId) {
 
-        Reservation reservation = reservationRepository.findByIdWithDetails(reservationId)
-                .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+        Reservation reservation = findReservationById(reservationId);
 
-        // 게스트 권한 검증 (게스트만 가능)
         if (!reservation.getGuestUser().getId().equals(userId)) {
             throw new ReservationException(ReservationErrorCode.RESERVATION_FORBIDDEN);
         }
 
-        // 상태 전이: 엔티티에게 취소 명령
-        reservation.cancel();
-
-        return ReservationUpdateStatusResponse.builder()
-                .reservationId(reservation.getId())
-                .status(reservation.getStatus())
-                .build();
+        return reservation;
     }
 }

--- a/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandServiceImpl.java
+++ b/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandServiceImpl.java
@@ -100,4 +100,24 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
 
         return reservation;
     }
+
+    @Override
+    public ReservationUpdateStatusResponse cancelReservation(Long reservationId, Long userId) {
+
+        Reservation reservation = reservationRepository.findByIdWithDetails(reservationId)
+                .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+
+        // 게스트 권한 검증 (게스트만 가능)
+        if (!reservation.getGuestUser().getId().equals(userId)) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_FORBIDDEN);
+        }
+
+        // 상태 전이: 엔티티에게 취소 명령
+        reservation.cancel();
+
+        return ReservationUpdateStatusResponse.builder()
+                .reservationId(reservation.getId())
+                .status(reservation.getStatus())
+                .build();
+    }
 }


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 -->

- Closes #92
- 게스트 사용자가 자신의 예약을 취소할 수 있는 기능을 구현

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 예약 취소 API 엔드포인트 추가 (PATCH /api/v1/reservations/{reservationId}/cancel)
- ReservationController 및 구현체에 취소 로직 추가
- ReservationCommandService / Impl에 cancelReservation 메서드 구현
- Reservation 엔티티에 cancel() 도메인 메서드 추가 (상태 전이 캡슐화)
- ReservationErrorCode에 취소 관련 에러코드 추가
  - RESERVATION_ALREADY_CANCELLED
  - RESERVATION_CANNOT_CANCEL
- ReservationSuccessMessage에 취소 성공 메시지 추가

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성
