### PR TITLE
feat: Implement rental start API

### DIFF
--- a/src/main/java/com/golfRental/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/golfRental/domain/reservation/controller/ReservationController.java
@@ -85,4 +85,16 @@ public interface ReservationController {
             Long reservationId,
             AuthUser authUser
     );
+
+    /**
+     * 대여 시작
+     *
+     * @param reservationId 예약 ID
+     * @param authUser      로그인 사용자 정보
+     * @return ReservationUpdateStatusResponse
+     */
+    ResponseEntity<CommonApiResponse<ReservationUpdateStatusResponse>> startReservation(
+            Long reservationId,
+            AuthUser authUser
+    );
 }

--- a/src/main/java/com/golfRental/domain/reservation/controller/ReservationControllerImpl.java
+++ b/src/main/java/com/golfRental/domain/reservation/controller/ReservationControllerImpl.java
@@ -117,4 +117,20 @@ public class ReservationControllerImpl implements ReservationController {
                 ReservationSuccessMessage.RESERVATION_CANCELLED
         );
     }
+
+    @Override
+    @PatchMapping("/{reservationId}/start")
+    public ResponseEntity<CommonApiResponse<ReservationUpdateStatusResponse>> startReservation(
+            @PathVariable Long reservationId,
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+        ReservationUpdateStatusResponse response =
+                reservationCommandService.startReservation(reservationId, authUser.getUserId());
+
+        return CommonApiResponse.success(
+                response,
+                ReservationSuccessMessage.RESERVATION_RENTAL_STARTED
+        );
+    }
+
 }

--- a/src/main/java/com/golfRental/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/golfRental/domain/reservation/entity/Reservation.java
@@ -53,15 +53,16 @@ public class Reservation extends BaseEntity {
     private User guestUser;
 
     @Builder
-    private Reservation(LocalDateTime reservationStartAt,
-                        LocalDateTime reservationEndAt,
-                        Integer price,
-                        Integer deposit,
-                        ReservationStatus status,
-                        Post post,
-                        User hostUser,
-                        User guestUser) {
-
+    private Reservation(
+            LocalDateTime reservationStartAt,
+            LocalDateTime reservationEndAt,
+            Integer price,
+            Integer deposit,
+            ReservationStatus status,
+            Post post,
+            User hostUser,
+            User guestUser
+    ) {
         this.reservationStartAt = reservationStartAt;
         this.reservationEndAt = reservationEndAt;
         this.price = price;
@@ -74,6 +75,7 @@ public class Reservation extends BaseEntity {
 
     // 예약 승인
     public void approve() {
+
         if (this.status == ReservationStatus.APPROVED) {
             throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_APPROVED);
         }
@@ -103,12 +105,10 @@ public class Reservation extends BaseEntity {
     // 예약 취소
     public void cancel() {
 
-        // 이미 취소된 경우
         if (this.status == ReservationStatus.CANCELLED) {
             throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_CANCELLED);
         }
 
-        // 취소가 허용되지 않는 상태
         if (this.status != ReservationStatus.REQUESTED &&
                 this.status != ReservationStatus.APPROVED) {
             throw new ReservationException(ReservationErrorCode.RESERVATION_CANNOT_CANCEL);
@@ -117,7 +117,7 @@ public class Reservation extends BaseEntity {
         this.status = ReservationStatus.CANCELLED;
     }
 
-    // 예약 대여 시작
+    // 대여 시작
     public void startRental() {
 
         if (this.status == ReservationStatus.RENTED) {

--- a/src/main/java/com/golfRental/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/golfRental/domain/reservation/entity/Reservation.java
@@ -116,4 +116,18 @@ public class Reservation extends BaseEntity {
 
         this.status = ReservationStatus.CANCELLED;
     }
+
+    // 예약 대여 시작
+    public void startRental() {
+
+        if (this.status == ReservationStatus.RENTED) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_RENTED);
+        }
+
+        if (this.status != ReservationStatus.APPROVED) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_CANNOT_START);
+        }
+
+        this.status = ReservationStatus.RENTED;
+    }
 }

--- a/src/main/java/com/golfRental/domain/reservation/exception/ReservationErrorCode.java
+++ b/src/main/java/com/golfRental/domain/reservation/exception/ReservationErrorCode.java
@@ -16,7 +16,9 @@ public enum ReservationErrorCode implements ErrorCode {
     RESERVATION_ALREADY_REJECTED(HttpStatus.BAD_REQUEST, "이미 거절된 예약입니다."),
     RESERVATION_CANNOT_REJECT(HttpStatus.BAD_REQUEST, "이 상태에서는 예약을 거절할 수 없습니다."),
     RESERVATION_ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "이미 취소된 예약입니다."),
-    RESERVATION_CANNOT_CANCEL(HttpStatus.BAD_REQUEST, "이 상태에서는 예약을 취소할 수 없습니다.");
+    RESERVATION_CANNOT_CANCEL(HttpStatus.BAD_REQUEST, "이 상태에서는 예약을 취소할 수 없습니다."),
+    RESERVATION_ALREADY_RENTED(HttpStatus.BAD_REQUEST, "이미 대여가 시작된 예약입니다."),
+    RESERVATION_CANNOT_START(HttpStatus.BAD_REQUEST, "이 상태에서는 대여를 시작할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/golfRental/domain/reservation/message/ReservationSuccessMessage.java
+++ b/src/main/java/com/golfRental/domain/reservation/message/ReservationSuccessMessage.java
@@ -8,6 +8,7 @@ public final class ReservationSuccessMessage {
     public final static String RESERVATION_APPROVED = "예약이 승인되었습니다.";
     public final static String RESERVATION_REJECTED = "예약이 거절되었습니다.";
     public final static String RESERVATION_CANCELLED = "예약이 취소되었습니다.";
+    public final static String RESERVATION_RENTAL_STARTED = "대여가 시작되었습니다.";
 
     private ReservationSuccessMessage() {
     }

--- a/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandService.java
+++ b/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandService.java
@@ -13,4 +13,6 @@ public interface ReservationCommandService {
     ReservationUpdateStatusResponse rejectReservation(Long reservationId, Long userId);
 
     ReservationUpdateStatusResponse cancelReservation(Long reservationId, Long userId);
+
+    ReservationUpdateStatusResponse startReservation(Long reservationId, Long userId);
 }

--- a/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandServiceImpl.java
+++ b/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandServiceImpl.java
@@ -107,8 +107,7 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
     @Override
     public ReservationUpdateStatusResponse startReservation(Long reservationId, Long userId) {
 
-        Reservation reservation = reservationRepository.findByIdWithDetails(reservationId)
-                .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+        Reservation reservation = findReservationById(reservationId);
 
         // 호스트만 시작 가능
         if (!reservation.getHostUser().getId().equals(userId)) {

--- a/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandServiceImpl.java
+++ b/src/main/java/com/golfRental/domain/reservation/service/command/ReservationCommandServiceImpl.java
@@ -103,6 +103,26 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
                 .build();
     }
 
+    // 대여 시작
+    @Override
+    public ReservationUpdateStatusResponse startReservation(Long reservationId, Long userId) {
+
+        Reservation reservation = reservationRepository.findByIdWithDetails(reservationId)
+                .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+
+        // 호스트만 시작 가능
+        if (!reservation.getHostUser().getId().equals(userId)) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_FORBIDDEN);
+        }
+
+        reservation.startRental(); // 엔티티 도메인 규칙 실행
+
+        return ReservationUpdateStatusResponse.builder()
+                .reservationId(reservation.getId())
+                .status(reservation.getStatus())
+                .build();
+    }
+
     // 공통 조회 메서드
     private Reservation findReservationById(Long reservationId) {
         return reservationRepository.findByIdWithDetails(reservationId)


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 -->

- Closes #93
- 호스트가 예약된 대여를 실제로 시작 처리하는 기능을 구현

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- PATCH /api/v1/reservations/{reservationId}/start API 구현
- 승인 상태(APPROVED) → 대여 시작(RENTED)로 상태 전환
- 권한 검증: 대여 시작은 호스트만 가능
- 이미 RENTED/RETURNING/COMPLETED 등 시작 불가 상태에 대한 예외 처리
- Reservation 엔티티에 start() 도메인 메서드 추가하여 상태 전이 규칙 캡슐화
- ReservationCommandService/Impl에 startReservation 로직 추가
- 성공 메시지(ReservationSuccessMessage) 및 에러 코드(ReservationErrorCode) 추가
- Controller/ControllerImpl API 정의 및 구현 반영 완료

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성
