### PR TITLE
feat: Implement reservation status query API

### DIFF
--- a/src/main/java/com/golfRental/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/golfRental/domain/reservation/controller/ReservationController.java
@@ -121,4 +121,16 @@ public interface ReservationController {
             Long reservationId,
             AuthUser authUser
     );
+
+    /**
+     * 예약 상태 조회
+     *
+     * @param reservationId 예약 ID
+     * @param authUser      로그인 사용자 정보
+     * @return ReservationUpdateStatusResponse
+     */
+    ResponseEntity<CommonApiResponse<ReservationUpdateStatusResponse>> getReservationStatus(
+            Long reservationId,
+            AuthUser authUser
+    );
 }

--- a/src/main/java/com/golfRental/domain/reservation/controller/ReservationControllerImpl.java
+++ b/src/main/java/com/golfRental/domain/reservation/controller/ReservationControllerImpl.java
@@ -163,4 +163,20 @@ public class ReservationControllerImpl implements ReservationController {
                 ReservationSuccessMessage.RETURN_COMPLETED
         );
     }
+
+    @Override
+    @GetMapping("/{reservationId}/status")
+    public ResponseEntity<CommonApiResponse<ReservationUpdateStatusResponse>> getReservationStatus(
+            @PathVariable Long reservationId,
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+
+        ReservationUpdateStatusResponse response =
+                reservationQueryService.getReservationStatus(reservationId, authUser.getUserId());
+
+        return CommonApiResponse.success(
+                response,
+                ReservationSuccessMessage.GET_RESERVATION_STATUS
+        );
+    }
 }

--- a/src/main/java/com/golfRental/domain/reservation/message/ReservationSuccessMessage.java
+++ b/src/main/java/com/golfRental/domain/reservation/message/ReservationSuccessMessage.java
@@ -11,6 +11,7 @@ public final class ReservationSuccessMessage {
     public final static String RESERVATION_RENTAL_STARTED = "대여가 시작되었습니다.";
     public final static String RETURN_REQUESTED = "반납 요청이 완료되었습니다.";
     public final static String RETURN_COMPLETED = "반납이 완료되었습니다.";
+    public final static String GET_RESERVATION_STATUS = "예약 상태 조회 성공";
 
     private ReservationSuccessMessage() {
     }

--- a/src/main/java/com/golfRental/domain/reservation/message/ReservationSuccessMessage.java
+++ b/src/main/java/com/golfRental/domain/reservation/message/ReservationSuccessMessage.java
@@ -11,7 +11,7 @@ public final class ReservationSuccessMessage {
     public final static String RESERVATION_RENTAL_STARTED = "대여가 시작되었습니다.";
     public final static String RETURN_REQUESTED = "반납 요청이 완료되었습니다.";
     public final static String RETURN_COMPLETED = "반납이 완료되었습니다.";
-    public final static String GET_RESERVATION_STATUS = "예약 상태 조회 성공";
+    public final static String GET_RESERVATION_STATUS = "예약 상태 조회에 성공하였습니다";
 
     private ReservationSuccessMessage() {
     }

--- a/src/main/java/com/golfRental/domain/reservation/service/query/ReservationQueryService.java
+++ b/src/main/java/com/golfRental/domain/reservation/service/query/ReservationQueryService.java
@@ -3,6 +3,7 @@ package com.golfRental.domain.reservation.service.query;
 import com.golfRental.common.response.SliceResponse;
 import com.golfRental.domain.reservation.dto.response.ReservationGetAllResponse;
 import com.golfRental.domain.reservation.dto.response.ReservationGetResponse;
+import com.golfRental.domain.reservation.dto.response.ReservationUpdateStatusResponse;
 import com.golfRental.domain.reservation.entity.Reservation;
 
 public interface ReservationQueryService {
@@ -12,4 +13,6 @@ public interface ReservationQueryService {
     Reservation findById(Long reservationId);
 
     SliceResponse<ReservationGetAllResponse> getMyReservations(Long userId, int page, int size);
+
+    ReservationUpdateStatusResponse getReservationStatus(Long reservationId, Long userId);
 }

--- a/src/main/java/com/golfRental/domain/reservation/service/query/ReservationQueryServiceImpl.java
+++ b/src/main/java/com/golfRental/domain/reservation/service/query/ReservationQueryServiceImpl.java
@@ -3,6 +3,7 @@ package com.golfRental.domain.reservation.service.query;
 import com.golfRental.common.response.SliceResponse;
 import com.golfRental.domain.reservation.dto.response.ReservationGetAllResponse;
 import com.golfRental.domain.reservation.dto.response.ReservationGetResponse;
+import com.golfRental.domain.reservation.dto.response.ReservationUpdateStatusResponse;
 import com.golfRental.domain.reservation.entity.Reservation;
 import com.golfRental.domain.reservation.exception.ReservationErrorCode;
 import com.golfRental.domain.reservation.exception.ReservationException;
@@ -84,5 +85,24 @@ public class ReservationQueryServiceImpl implements ReservationQueryService {
         );
 
         return SliceResponse.fromSlice(contents);
+    }
+
+    // 예약 상태 조회
+    @Override
+    public ReservationUpdateStatusResponse getReservationStatus(Long reservationId, Long userId) {
+
+        Reservation reservation = reservationRepository.findByIdWithDetails(reservationId)
+                .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+
+        // 호스트 또는 게스트만 조회 가능
+        if (!reservation.getHostUser().getId().equals(userId)
+                && !reservation.getGuestUser().getId().equals(userId)) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_FORBIDDEN);
+        }
+
+        return ReservationUpdateStatusResponse.builder()
+                .reservationId(reservation.getId())
+                .status(reservation.getStatus())
+                .build();
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 -->

- Closes #96
- 예약 단건 상태 조회 API 추가

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 단일 예약의 현재 상태를 조회하는 API를 구현
- 호스트 또는 게스트만 조회할 수 있도록 권한 검증을 추가
- ReservationUpdateStatusResponse를 재사용하여 일관된 응답 구조 유지
- Controller / QueryService 인터페이스·구현체 분리 적용

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성
