### PR TITLE
fix: Remove DB unique constraint on category name to support soft delete reuse

### DIFF
--- a/src/main/java/com/golfRental/domain/category/entity/Category.java
+++ b/src/main/java/com/golfRental/domain/category/entity/Category.java
@@ -17,7 +17,7 @@ public class Category extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true, length = 50)
+    @Column(nullable = false, length = 50)
     private String name;
 
     @Builder


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 -->

- Closes #104

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- Entity에서 @Column unique 제약을 제거하여 soft delete 환경에서 동일한 카테고리 이름 재사용 가능하도록 개선
- 애플리케이션 레벨에서 삭제되지 않은 카테고리만 중복 검증 수행
- Category 엔티티의 name 컬럼에서 `unique = true` 제약 제거

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성
