### PR TITLE
feat: Implement point transaction history API

### DIFF
--- a/src/main/java/com/golfRental/domain/point/controller/PointController.java
+++ b/src/main/java/com/golfRental/domain/point/controller/PointController.java
@@ -1,13 +1,20 @@
 package com.golfRental.domain.point.controller;
 
 import com.golfRental.common.response.CommonApiResponse;
+import com.golfRental.common.response.SliceResponse;
 import com.golfRental.domain.auth.dto.AuthUser;
 import com.golfRental.domain.point.dto.response.PointBalanceResponse;
+import com.golfRental.domain.point.dto.response.PointTransactionGetResponse;
 import org.springframework.http.ResponseEntity;
 
 public interface PointController {
 
     ResponseEntity<CommonApiResponse<PointBalanceResponse>> getMyPointBalance(
-            AuthUser authUser
+            AuthUser authUser);
+
+    ResponseEntity<CommonApiResponse<SliceResponse<PointTransactionGetResponse>>> getMyTransactions(
+            AuthUser authUser,
+            int page,
+            int size
     );
 }

--- a/src/main/java/com/golfRental/domain/point/controller/PointControllerImpl.java
+++ b/src/main/java/com/golfRental/domain/point/controller/PointControllerImpl.java
@@ -1,15 +1,19 @@
 package com.golfRental.domain.point.controller;
 
 import com.golfRental.common.response.CommonApiResponse;
+import com.golfRental.common.response.SliceResponse;
 import com.golfRental.domain.auth.dto.AuthUser;
 import com.golfRental.domain.point.dto.response.PointBalanceResponse;
+import com.golfRental.domain.point.dto.response.PointTransactionGetResponse;
 import com.golfRental.domain.point.message.PointSuccessMessage;
 import com.golfRental.domain.point.service.command.PointCommandService;
+import com.golfRental.domain.point.service.query.PointQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PointControllerImpl implements PointController {
 
     private final PointCommandService pointCommandService;
+    private final PointQueryService pointQueryService;
 
     @Override
     @GetMapping("/balance")
@@ -30,6 +35,22 @@ public class PointControllerImpl implements PointController {
         return CommonApiResponse.success(
                 response,
                 PointSuccessMessage.GET_POINT_BALANCE
+        );
+    }
+
+    @Override
+    @GetMapping("/transactions")
+    public ResponseEntity<CommonApiResponse<SliceResponse<PointTransactionGetResponse>>> getMyTransactions(
+            @AuthenticationPrincipal AuthUser authUser,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        SliceResponse<PointTransactionGetResponse> response =
+                pointQueryService.getMyTransactions(authUser.getUserId(), page, size);
+
+        return CommonApiResponse.success(
+                response,
+                PointSuccessMessage.POINT_TRANSACTION_LIST
         );
     }
 }

--- a/src/main/java/com/golfRental/domain/point/dto/response/PointTransactionGetResponse.java
+++ b/src/main/java/com/golfRental/domain/point/dto/response/PointTransactionGetResponse.java
@@ -1,0 +1,16 @@
+package com.golfRental.domain.point.dto.response;
+
+import com.golfRental.domain.point.enums.PointTransactionType;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record PointTransactionGetResponse(
+        Long transactionId,
+        Integer amount,
+        PointTransactionType type,
+        Integer balanceAfter,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/golfRental/domain/point/dto/response/PointTransactionGetResponse.java
+++ b/src/main/java/com/golfRental/domain/point/dto/response/PointTransactionGetResponse.java
@@ -8,9 +8,9 @@ import java.time.LocalDateTime;
 @Builder
 public record PointTransactionGetResponse(
         Long transactionId,
-        Integer amount,
+        Long amount,
         PointTransactionType type,
-        Integer balanceAfter,
+        Long balanceAfter,
         LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/golfRental/domain/point/message/PointSuccessMessage.java
+++ b/src/main/java/com/golfRental/domain/point/message/PointSuccessMessage.java
@@ -3,6 +3,7 @@ package com.golfRental.domain.point.message;
 public final class PointSuccessMessage {
 
     public final static String GET_POINT_BALANCE = "포인트 잔액 조회에 성공하였습니다.";
+    public final static String POINT_TRANSACTION_LIST = "포인트 거래 내역 조회에 성공하였습니다.";
 
     private PointSuccessMessage() {
     }

--- a/src/main/java/com/golfRental/domain/point/repository/PointTransactionRepository.java
+++ b/src/main/java/com/golfRental/domain/point/repository/PointTransactionRepository.java
@@ -11,7 +11,7 @@ public interface PointTransactionRepository extends JpaRepository<PointTransacti
     @Query("""
             SELECT t
             FROM PointTransaction t
-            JOIN FETCH t.user u
+            JOIN t.user u
             WHERE u.id = :userId
             AND t.deletedAt IS NULL
             ORDER BY t.id DESC

--- a/src/main/java/com/golfRental/domain/point/repository/PointTransactionRepository.java
+++ b/src/main/java/com/golfRental/domain/point/repository/PointTransactionRepository.java
@@ -1,7 +1,20 @@
 package com.golfRental.domain.point.repository;
 
 import com.golfRental.domain.point.entity.PointTransaction;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PointTransactionRepository extends JpaRepository<PointTransaction, Long> {
+
+    @Query("""
+            SELECT t
+            FROM PointTransaction t
+            JOIN FETCH t.user u
+            WHERE u.id = :userId
+            AND t.deletedAt IS NULL
+            ORDER BY t.id DESC
+            """)
+    Slice<PointTransaction> findByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/golfRental/domain/point/service/query/PointQueryService.java
+++ b/src/main/java/com/golfRental/domain/point/service/query/PointQueryService.java
@@ -1,0 +1,9 @@
+package com.golfRental.domain.point.service.query;
+
+import com.golfRental.common.response.SliceResponse;
+import com.golfRental.domain.point.dto.response.PointTransactionGetResponse;
+
+public interface PointQueryService {
+
+    SliceResponse<PointTransactionGetResponse> getMyTransactions(Long userId, int page, int size);
+}

--- a/src/main/java/com/golfRental/domain/point/service/query/PointQueryServiceImpl.java
+++ b/src/main/java/com/golfRental/domain/point/service/query/PointQueryServiceImpl.java
@@ -3,20 +3,15 @@ package com.golfRental.domain.point.service.query;
 
 import com.golfRental.common.response.SliceResponse;
 import com.golfRental.domain.point.dto.response.PointTransactionGetResponse;
-import com.golfRental.domain.point.entity.PointAccount;
 import com.golfRental.domain.point.entity.PointTransaction;
-import com.golfRental.domain.point.repository.PointAccountRepository;
 import com.golfRental.domain.point.repository.PointTransactionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Slf4j
 @Service
@@ -24,22 +19,10 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class PointQueryServiceImpl implements PointQueryService {
 
-
     private final PointTransactionRepository transactionRepository;
-    private final PointAccountRepository pointAccountRepository;
 
     @Override
     public SliceResponse<PointTransactionGetResponse> getMyTransactions(Long userId, int page, int size) {
-
-        // 계좌가 없으면 빈 SliceResponse 반환
-        PointAccount account = pointAccountRepository.findByUserId(userId)
-                .orElse(null);
-
-        if (account == null) {
-            Slice<PointTransactionGetResponse> emptySlice =
-                    new PageImpl<>(List.of(), PageRequest.of(page, size), 0);
-            return SliceResponse.fromSlice(emptySlice);
-        }
 
         Pageable pageable = PageRequest.of(page, size);
 
@@ -49,9 +32,9 @@ public class PointQueryServiceImpl implements PointQueryService {
         Slice<PointTransactionGetResponse> contents = transactions.map(transaction ->
                 PointTransactionGetResponse.builder()
                         .transactionId(transaction.getId())
-                        .amount(transaction.getAmount().intValue())
+                        .amount(transaction.getAmount())
                         .type(transaction.getType())
-                        .balanceAfter(transaction.getBalanceAfter().intValue())
+                        .balanceAfter(transaction.getBalanceAfter())
                         .createdAt(transaction.getCreatedAt())
                         .build()
         );

--- a/src/main/java/com/golfRental/domain/point/service/query/PointQueryServiceImpl.java
+++ b/src/main/java/com/golfRental/domain/point/service/query/PointQueryServiceImpl.java
@@ -1,0 +1,61 @@
+package com.golfRental.domain.point.service.query;
+
+
+import com.golfRental.common.response.SliceResponse;
+import com.golfRental.domain.point.dto.response.PointTransactionGetResponse;
+import com.golfRental.domain.point.entity.PointAccount;
+import com.golfRental.domain.point.entity.PointTransaction;
+import com.golfRental.domain.point.repository.PointAccountRepository;
+import com.golfRental.domain.point.repository.PointTransactionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PointQueryServiceImpl implements PointQueryService {
+
+
+    private final PointTransactionRepository transactionRepository;
+    private final PointAccountRepository pointAccountRepository;
+
+    @Override
+    public SliceResponse<PointTransactionGetResponse> getMyTransactions(Long userId, int page, int size) {
+
+        // 계좌가 없으면 빈 SliceResponse 반환
+        PointAccount account = pointAccountRepository.findByUserId(userId)
+                .orElse(null);
+
+        if (account == null) {
+            Slice<PointTransactionGetResponse> emptySlice =
+                    new PageImpl<>(List.of(), PageRequest.of(page, size), 0);
+            return SliceResponse.fromSlice(emptySlice);
+        }
+
+        Pageable pageable = PageRequest.of(page, size);
+
+        Slice<PointTransaction> transactions =
+                transactionRepository.findByUserId(userId, pageable);
+
+        Slice<PointTransactionGetResponse> contents = transactions.map(transaction ->
+                PointTransactionGetResponse.builder()
+                        .transactionId(transaction.getId())
+                        .amount(transaction.getAmount().intValue())
+                        .type(transaction.getType())
+                        .balanceAfter(transaction.getBalanceAfter().intValue())
+                        .createdAt(transaction.getCreatedAt())
+                        .build()
+        );
+
+        return SliceResponse.fromSlice(contents);
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 -->

- Closes #172
- 사용자별 포인트 거래 내역 조회 기능 구현

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- GET /api/v1/points/transactions 엔드포인트 추가
- 페이징 처리를 통해 많은 거래 내역도 효율적으로 조회 가능 (기본값: page=0, size=10)
- 포인트 계좌가 없는 신규 사용자의 경우 빈 목록을 반환하여 안정적인 API 응답 제공
- PointQueryService를 통해 읽기 전용 트랜잭션으로 거래 내역 조회 로직 분리
- JOIN FETCH를 사용하여 N+1 문제를 방지하고 최신 거래 내역 우선 반환


## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성
