### PR TITLE
fix: Support JWT authentication via query parameter for SSE

### DIFF
--- a/src/main/java/com/golfRental/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/golfRental/security/filter/JwtAuthenticationFilter.java
@@ -37,32 +37,55 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(
-            HttpServletRequest httpRequest,
-            @NonNull HttpServletResponse httpResponse,
+            HttpServletRequest request,
+            @NonNull HttpServletResponse response,
             @NonNull FilterChain chain
     ) throws ServletException, IOException {
-        // HTTP 요청 헤더에서 "Authorization" 헤더값을 가져옴
-        String authorizationHeader = httpRequest.getHeader("Authorization");
 
-        // Authorization 헤더가 없거나 "Bearer "로 시작하지 않으면 JWT 인증을 건너뜀
-        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-            chain.doFilter(httpRequest, httpResponse);
+        // JWT 추출 로직 통합
+        String jwt = resolveToken(request);
+
+        // 토큰이 없으면 인증 시도 없이 다음 필터
+        if (jwt == null) {
+            chain.doFilter(request, response);
             return;
         }
-
-        String jwt = jwtUtil.substringToken(authorizationHeader);
 
         // JWT 검증 및 인증 설정
-        if (!processAuthentication(jwt, httpRequest, httpResponse)) {
+        if (!processAuthentication(jwt, request, response)) {
             return;
         }
 
-        // JWT 검증 성공 시 다음 필터로 요청 전달
-        chain.doFilter(httpRequest, httpResponse);
+        chain.doFilter(request, response);
+    }
+
+    /**
+     * JWT 토큰 추출
+     * Authorization Header (Bearer)
+     * access_token Query Parameter (SSE 대응)
+     */
+    private String resolveToken(HttpServletRequest request) {
+        // 1. Authorization Header 우선
+        String authorizationHeader = request.getHeader("Authorization");
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            return jwtUtil.substringToken(authorizationHeader);
+        }
+
+        // 2. SSE 대응: Query Parameter
+        String accessToken = request.getParameter("access_token");
+        if (accessToken != null && !accessToken.isBlank()) {
+            return accessToken;
+        }
+
+        return null;
     }
 
     // JWT 토큰을 검증하고 SecurityContext에 인증 정보를 설정하는 메서드
-    private boolean processAuthentication(String jwt, HttpServletRequest request, HttpServletResponse response) throws IOException {
+    private boolean processAuthentication(
+            String jwt,
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) throws IOException {
         try {
             // JWT 토큰을 파싱하여 Claims(토큰에 담긴 정보) 추출
             Claims claims = jwtUtil.extractClaims(jwt);
@@ -98,7 +121,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return false;
 
         } catch (Exception e) {
-            log.error("예상치 못한 JWT 검증 오류: URI={}", request.getRequestURI(), e);
+            log.error("JWT 검증 중 서버 오류: URI={}", request.getRequestURI(), e);
             sendErrorResponse(response, HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
 
             return false;
@@ -112,21 +135,24 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         // 커스텀 claim에서 사용자 권한 정보를 추출하여 enum으로 변환
         UserRole userRole = UserRole.of(claims.get("userRole", String.class));
 
-        // 추출한 정보로 인증된 사용자 객체 생성
         AuthUser authUser = new AuthUser(userId, userRole);
-        // Spring Security가 인식할 수 있는 Authentication 객체 생성
-        Authentication authenticationToken = new JwtAuthenticationToken(authUser);
-        // SecurityContext에 인증 정보 저장 - 이후 @AuthenticationPrincipal로 접근 가능
-        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+        Authentication authentication = new JwtAuthenticationToken(authUser);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
-    private void sendErrorResponse(HttpServletResponse response, HttpStatus status, String message) throws IOException {
+    private void sendErrorResponse(
+            HttpServletResponse response,
+            HttpStatus status,
+            String message
+    ) throws IOException {
         response.setStatus(status.value());
         response.setContentType("application/json;charset=UTF-8");
+
         Map<String, Object> errorResponse = new HashMap<>();
         errorResponse.put("status", status.name());
         errorResponse.put("code", status.value());
         errorResponse.put("message", message);
+
         response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
     }
 }

--- a/src/main/java/com/golfRental/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/golfRental/security/filter/JwtAuthenticationFilter.java
@@ -32,6 +32,8 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    private static final String BEARER_PREFIX = "bearer ";
+
     private final JwtUtil jwtUtil;
     private final ObjectMapper objectMapper;
 
@@ -61,26 +63,32 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     /**
      * JWT 토큰 추출
-     * Authorization Header (Bearer)
-     * access_token Query Parameter (SSE 대응)
+     * 1. Authorization Header (Bearer, case-insensitive)
+     * 2. access_token Query Parameter (SSE 대응)
      */
     private String resolveToken(HttpServletRequest request) {
+
         // 1. Authorization Header 우선
         String authorizationHeader = request.getHeader("Authorization");
-        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-            return jwtUtil.substringToken(authorizationHeader);
+        if (authorizationHeader != null &&
+                authorizationHeader.toLowerCase().startsWith(BEARER_PREFIX)) {
+
+            return authorizationHeader.substring(BEARER_PREFIX.length());
         }
 
         // 2. SSE 대응: Query Parameter
         String accessToken = request.getParameter("access_token");
         if (accessToken != null && !accessToken.isBlank()) {
+            if (accessToken.toLowerCase().startsWith(BEARER_PREFIX)) {
+                return accessToken.substring(BEARER_PREFIX.length());
+            }
             return accessToken;
         }
 
         return null;
     }
 
-    // JWT 토큰을 검증하고 SecurityContext에 인증 정보를 설정하는 메서드
+    // JWT 토큰을 검증하고 SecurityContext에 인증 정보를 설정
     private boolean processAuthentication(
             String jwt,
             HttpServletRequest request,


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 -->

- Closes #324

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- SSE(EventSource) 연결 시 Authorization 헤더를 사용할 수 없는 브라우저 제약 문제를 해결
- JwtAuthenticationFilter에서 기존 Authorization 헤더 기반 인증 로직은 그대로 유지
- 헤더가 없는 경우 access_token 쿼리 파라미터로 전달된 JWT를 fallback 방식으로 인증하도록 개선
- SSE 실시간 알림 구독 요청도 정상적으로 인증 처리되며, 기존 REST API 및 보안 흐름에는 영향을 주지 않도록 분리 설계

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성
