### PR TITLE
 fix: Prevent JWT filter from blocking public endpoints

### DIFF
--- a/src/main/java/com/golfRental/security/config/SecurityConfig.java
+++ b/src/main/java/com/golfRental/security/config/SecurityConfig.java
@@ -54,37 +54,27 @@ public class SecurityConfig {
 
                 .authorizeHttpRequests(auth -> auth
 
+                        // Swagger / Actuator
                         .requestMatchers(
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
-                                "/swagger-ui.html")
-                        .permitAll()
+                                "/swagger-ui.html",
+                                "/actuator/**"
+                        ).permitAll()
 
-                        .requestMatchers(
-                                "/actuator/**")
-                        .permitAll()
-
+                        // Auth
                         .requestMatchers(HttpMethod.POST,
-                                "/api/v1/signup",
-                                "/api/v1/login")
-                        .permitAll()
+                                "/api/v1/login",
+                                "/api/v1/signup"
+                        ).permitAll()
 
+                        // Public API
                         .requestMatchers(HttpMethod.GET,
-                                "/actuator/health",
-                                "/actuator/info",
-                                "/actuator/prometheus")
-                        .permitAll()
+                                "/api/v1/categories/**",
+                                "/api/v1/public/posts/**"
+                        ).permitAll()
 
-                        .requestMatchers(HttpMethod.GET,
-                                "/api/v1/categories",
-                                "/api/v1/categories/*")
-                        .permitAll()
-
-                        .requestMatchers(HttpMethod.GET,
-                                "/api/v1/public/posts",
-                                "/api/v1/public/posts/*")
-                        .permitAll()
-
+                        // Admin
                         .requestMatchers("/api/v1/admin/**")
                         .hasRole("ADMIN")
 

--- a/src/main/java/com/golfRental/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/golfRental/security/filter/JwtAuthenticationFilter.java
@@ -17,6 +17,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -36,6 +37,39 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
     private final ObjectMapper objectMapper;
+
+    /**
+     * 인증이 필요 없는 경로는 JWT 필터 자체를 타지 않음
+     */
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+
+        // CORS Preflight 요청은 무조건 제외
+        if (HttpMethod.OPTIONS.matches(request.getMethod())) {
+            return true;
+        }
+
+        return
+                // Auth
+                path.startsWith("/api/v1/login") ||
+                        path.startsWith("/api/v1/signup") ||
+
+                        // Public API
+                        path.startsWith("/api/v1/public") ||
+
+                        // Swagger / Actuator
+                        path.startsWith("/v3/api-docs") ||
+                        path.startsWith("/swagger-ui") ||
+                        path.startsWith("/actuator") ||
+
+                        // Static / Front entry
+                        path.equals("/") ||
+                        path.startsWith("/favicon") ||
+                        path.startsWith("/static") ||
+                        path.startsWith("/assets") ||
+                        path.endsWith(".html");
+    }
 
     @Override
     protected void doFilterInternal(
@@ -68,7 +102,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
      */
     private String resolveToken(HttpServletRequest request) {
 
-        // 1. Authorization Header 우선
+        // 1. Authorization Header
         String authorizationHeader = request.getHeader("Authorization");
         if (authorizationHeader != null &&
                 authorizationHeader.toLowerCase().startsWith(BEARER_PREFIX)) {
@@ -76,7 +110,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return authorizationHeader.substring(BEARER_PREFIX.length());
         }
 
-        // 2. SSE 대응: Query Parameter
+        // 2. SSE Query Parameter
         String accessToken = request.getParameter("access_token");
         if (accessToken != null && !accessToken.isBlank()) {
             if (accessToken.toLowerCase().startsWith(BEARER_PREFIX)) {
@@ -94,6 +128,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             HttpServletRequest request,
             HttpServletResponse response
     ) throws IOException {
+
         try {
             // JWT 토큰을 파싱하여 Claims(토큰에 담긴 정보) 추출
             Claims claims = jwtUtil.extractClaims(jwt);
@@ -104,32 +139,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
             return true; // 검증 성공
 
-        } catch (SignatureException e) {
-            log.warn("JWT 서명 불일치: URI={}", request.getRequestURI(), e);
-            sendErrorResponse(response, HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 서명입니다.");
-
-            return false;
-
-        } catch (MalformedJwtException e) {
-            log.warn("잘못된 JWT 형식: URI={}", request.getRequestURI(), e);
-            sendErrorResponse(response, HttpStatus.UNAUTHORIZED, "잘못된 JWT 토큰입니다.");
-
+        } catch (SignatureException | MalformedJwtException | UnsupportedJwtException e) {
+            sendErrorResponse(response, HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다.");
             return false;
 
         } catch (ExpiredJwtException e) {
-            log.warn("JWT 만료: userId={}, URI={}", e.getClaims().getSubject(), request.getRequestURI());
             sendErrorResponse(response, HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다.");
-
-            return false;
-
-        } catch (UnsupportedJwtException e) {
-            log.warn("지원되지 않는 JWT: URI={}", request.getRequestURI(), e);
-            sendErrorResponse(response, HttpStatus.UNAUTHORIZED, "지원되지 않는 JWT 토큰입니다.");
-
             return false;
 
         } catch (Exception e) {
-            log.error("JWT 검증 중 서버 오류: URI={}", request.getRequestURI(), e);
+            log.error("JWT 처리 중 서버 오류", e);
             sendErrorResponse(response, HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
 
             return false;
@@ -153,14 +172,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             HttpStatus status,
             String message
     ) throws IOException {
+
         response.setStatus(status.value());
         response.setContentType("application/json;charset=UTF-8");
 
-        Map<String, Object> errorResponse = new HashMap<>();
-        errorResponse.put("status", status.name());
-        errorResponse.put("code", status.value());
-        errorResponse.put("message", message);
+        Map<String, Object> body = new HashMap<>();
+        body.put("status", status.name());
+        body.put("code", status.value());
+        body.put("message", message);
 
-        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+        response.getWriter().write(objectMapper.writeValueAsString(body));
     }
 }

--- a/src/main/java/com/golfRental/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/golfRental/security/filter/JwtAuthenticationFilter.java
@@ -39,7 +39,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final ObjectMapper objectMapper;
 
     /**
-     * 인증이 필요 없는 경로는 JWT 필터 자체를 타지 않음
+     * SecurityConfig의 permitAll 규칙과 정확히 일치하도록
+     * JWT 필터 제외 경로 + HTTP Method를 함께 검사
      */
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
@@ -52,11 +53,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         return
                 // Auth
-                path.startsWith("/api/v1/login") ||
-                        path.startsWith("/api/v1/signup") ||
+                (HttpMethod.POST.matches(request.getMethod()) &&
+                        (path.startsWith("/api/v1/login") ||
+                                path.startsWith("/api/v1/signup"))) ||
 
                         // Public API
-                        path.startsWith("/api/v1/public") ||
+                        (HttpMethod.GET.matches(request.getMethod()) &&
+                                (path.startsWith("/api/v1/categories") ||
+                                        path.startsWith("/api/v1/public/posts"))) ||
 
                         // Swagger / Actuator
                         path.startsWith("/v3/api-docs") ||
@@ -140,17 +144,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return true; // 검증 성공
 
         } catch (SignatureException | MalformedJwtException | UnsupportedJwtException e) {
+            log.warn("유효하지 않은 JWT 토큰입니다. uri={}", request.getRequestURI());
             sendErrorResponse(response, HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다.");
             return false;
 
         } catch (ExpiredJwtException e) {
+            log.warn(
+                    "만료된 JWT 토큰입니다. userId={}, uri={}",
+                    e.getClaims().getSubject(),
+                    request.getRequestURI()
+            );
             sendErrorResponse(response, HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다.");
             return false;
 
         } catch (Exception e) {
             log.error("JWT 처리 중 서버 오류", e);
             sendErrorResponse(response, HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
-
             return false;
         }
     }


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 -->

- Closes #332 

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- JWT 인증 필터가 permitAll로 설정된 public 엔드포인트까지 인증을 시도하면서 로그인 API(/api/v1/login) 및 메인/정적 리소스 접근 시 403 Forbidden이 발생하던 문제를 해결
- JWT 필터의 적용 범위를 명확히 분리하고, Spring Security 인가 설정과 필터 동작을 일관되게 정렬하여 인증 흐름을 안정화

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성
