### PR TITLE
fix: Allow CORS preflight requests in SecurityConfig

### DIFF
--- a/src/main/java/com/golfRental/security/config/SecurityConfig.java
+++ b/src/main/java/com/golfRental/security/config/SecurityConfig.java
@@ -54,6 +54,9 @@ public class SecurityConfig {
 
                 .authorizeHttpRequests(auth -> auth
 
+                        // CORS Preflight (OPTIONS) 요청 전역 허용
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+
                         // Root (API 서버 진입점)
                         .requestMatchers("/").permitAll()
 

--- a/src/main/java/com/golfRental/security/config/SecurityConfig.java
+++ b/src/main/java/com/golfRental/security/config/SecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter;
+import org.springframework.web.cors.CorsUtils;
 
 @Configuration
 @RequiredArgsConstructor
@@ -33,7 +34,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
         return http
-                // WebConfig(WebMvcConfigurer)의 CORS 설정을 사용하도록 명시
+                // WebConfig(WebMvcConfigurer)의 CORS 설정을 사용
                 .cors(Customizer.withDefaults())
 
                 .csrf(AbstractHttpConfigurer::disable)
@@ -54,8 +55,8 @@ public class SecurityConfig {
 
                 .authorizeHttpRequests(auth -> auth
 
-                        // CORS Preflight (OPTIONS) 요청 전역 허용
-                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        // CORS Preflight 요청만 명확히 허용
+                        .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
 
                         // Root (API 서버 진입점)
                         .requestMatchers("/").permitAll()


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 -->

- Closes #336

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- CORS Preflight(OPTIONS) 요청이 SecurityConfig의 인증 규칙에 의해 403 Forbidden으로 차단되던 문제를 수정
- HttpMethod.OPTIONS /** 경로를 permitAll로 전역 허용
- anyRequest().authenticated()보다 우선 적용되도록 순서 보장
- Vercel(HTTPS) → EC2(Nginx) → Spring 구조에서 브라우저 CORS 요청이 정상 처리되도록 개선

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성
